### PR TITLE
fix(menu): show only "real" posts and not "dynamic" pages  in most recent posts

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -3,7 +3,7 @@
     <div id="last-posts" class="open">
         <h3 data-open="last-posts">{{ .Site.Title }} - {{ ( index $.Site.Data.translations $.Site.Params.locale ).mostrecentposts }}</h3>
         <ul>
-            {{ range first 10 .Site.Pages }}
+            {{ range first 10 .Site.RegularPages }}
             <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
             {{ end }}
         </ul>


### PR DESCRIPTION
When there are few pages in the site, .Site.Pages will show also some dynamically generated taxonomy pages in the most recent posts section of the menu (along with some entirely broken links). .Site.RegularPages will only display the regular pages instead of displaying all pages in the site.