### PR TITLE
add BaseURL for js and css

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,2 +1,2 @@
-<script src="js/theme.min.js" type="text/javascript"></script>
+<script src="{{ .Site.BaseURL }}/js/theme.min.js" type="text/javascript"></script>
 {{ template "_internal/google_analytics.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,4 +11,4 @@
 {{ .Hugo.Generator }}
 {{ partial "highlightjs.html" }}
 <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700" rel="stylesheet" type="text/css">
-<link  href="{{ .Site.BaseURL }}css/theme.min.css" rel="stylesheet" type="text/css">
+<link  href="{{ .Site.BaseURL }}/css/theme.min.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
If BaseURL=https://xxx.com/blog

In head.html, a js location is assembled as such `src=https://xxx.com/blogcss/theme.min.css` but it should be `src=https://xxx.com/blog/css/theme.min.css`


In footer.html, the js location is `src="js/theme.min.js"` which should instead point to `blog/js/theme.min.js`
