### PR TITLE
Root link in menu configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,7 @@ theme = "code-editor"
     author = "John Doe"
     locale = "en-US"
     # rootlink = "/"
-    # rootlink specifies where Root in menu.html links to. 
-    # 1. If it's not set than baseurl will be used.
-    # 2. If it's set to a url with a scheme, like rootlink="https://www.google.com",
-    #    then Root will link to https://www.google.com.
-    # 3. If it's set to a path(without scheme), like rootlink="doc", then Root
-    #    will link to "doc", which should work fine in the brower.
+    # rootlink specifies where Root in menu.html links to. If it's not set than baseurl will be used.
 ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You will need to define the `locale` parameter in order to use this theme.
 Please have a look at this configuraton sample :
 
 ```
-baseurl = "http://your-site.com"
+baseurl = "http://your-site.com/blog"
 languageCode = "en-US"
 title = "Your site"
 theme = "code-editor"
@@ -26,6 +26,14 @@ theme = "code-editor"
 [params]
     author = "John Doe"
     locale = "en-US"
+    # rootlink = "/"
+    # rootlink specifies where Root in menu.html links to. 
+    # 1. If it's not set than baseurl will be used.
+    # 2. If it's set to a url with a scheme, like rootlink="https://www.google.com",
+    #    then Root will link to https://www.google.com.
+    # 3. If it's set to a path(without scheme), like rootlink="doc", then Root
+    #    will link to an url concatenated by host in baseurl and rootlink. In
+    #    this case, it comes up with http://your-site.com/doc.
 ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ theme = "code-editor"
     # 2. If it's set to a url with a scheme, like rootlink="https://www.google.com",
     #    then Root will link to https://www.google.com.
     # 3. If it's set to a path(without scheme), like rootlink="doc", then Root
-    #    will link to an url concatenated by host in baseurl and rootlink. In
-    #    this case, it comes up with http://your-site.com/doc.
+    #    will link to "doc", which should work fine in the brower.
 ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You will need to define the `locale` parameter in order to use this theme.
 Please have a look at this configuraton sample :
 
 ```
-baseurl = "http://your-site.com/blog"
+baseurl = "http://your-site.com"
 languageCode = "en-US"
 title = "Your site"
 theme = "code-editor"
@@ -27,7 +27,7 @@ theme = "code-editor"
     author = "John Doe"
     locale = "en-US"
     # rootlink = "/"
-    # rootlink specifies where Root in menu.html links to. If it's not set than baseurl will be used.
+    # rootlink specifies where Root in menu.html links to. If it's not set then baseurl will be used.
 ```
 
 # Contributing

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,5 +1,5 @@
 <nav class="col-md-3">
-    <h3 class="home-link"><a href="{{ .Site.BaseURL }}">{{ ( index $.Site.Data.translations $.Site.Params.locale ).root }}</a></h3>
+    <h3 class="home-link"><a href="{{ index .Site.Params "rootlink" | default .Site.BaseURL }}">{{ ( index $.Site.Data.translations $.Site.Params.locale ).root }}</a></h3>
     <div id="last-posts" class="open">
         <h3 data-open="last-posts">{{ .Site.Title }} - {{ ( index $.Site.Data.translations $.Site.Params.locale ).mostrecentposts }}</h3>
         <ul>

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,5 +1,5 @@
 <nav class="col-md-3">
-    <h3 class="home-link"><a href="/">{{ ( index $.Site.Data.translations $.Site.Params.locale ).root }}</a></h3>
+    <h3 class="home-link"><a href="{{ .Site.BaseURL }}">{{ ( index $.Site.Data.translations $.Site.Params.locale ).root }}</a></h3>
     <div id="last-posts" class="open">
         <h3 data-open="last-posts">{{ .Site.Title }} - {{ ( index $.Site.Data.translations $.Site.Params.locale ).mostrecentposts }}</h3>
         <ul>


### PR DESCRIPTION
This PR is for #5.

I add Params.rootlink for that purpose. Extracted from updated README:
```
baseurl = "http://your-site.com/blog"
languageCode = "en-US"
title = "Your site"
theme = "code-editor"

[params]
    author = "John Doe"
    locale = "en-US"
    # rootlink = "/"
    # rootlink specifies where Root in menu.html links to.
    # 1. If it's not set than baseurl will be used.
    # 2. If it's set to a url(w/ a scheme), like rootlink="https://www.google.com",
    #    then Root will link to https://www.google.com.
    # 3. If it's set to a path(w/o a scheme), like rootlink="doc", then Root
    #    will link to an url concatenated by host in baseurl and rootlink. In
    #    this case, it comes up with http://your-site.com/doc.
```