### PR TITLE
introduce setting to hide "Most recent posts"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ theme = "code-editor"
     # rootlink specifies where Root in menu.html links to. If it's not set then baseurl will be used.
 ```
 
+In addition to the required settings, you can customize this theme using the following keys within `[params]`:
+
+* `codeeditor_menu_mostrecentposts`, defaults to `true`, whether to show the "Most recent posts" section within the menu
+
 # Contributing
 
 Contributions are welcome. Please refer to the [contributions guidelines](https://github.com/aubm/hugo-code-editor-theme/blob/master/CONTRIBUTING.md) for more information.

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,5 +1,6 @@
 <nav class="col-md-3">
     <h3 class="home-link"><a href="{{ index .Site.Params "rootlink" | default .Site.BaseURL }}">{{ ( index $.Site.Data.translations $.Site.Params.locale ).root }}</a></h3>
+    {{ if $.Site.Params.codeeditor_menu_mostrecentposts | default true }}
     <div id="last-posts" class="open">
         <h3 data-open="last-posts">{{ .Site.Title }} - {{ ( index $.Site.Data.translations $.Site.Params.locale ).mostrecentposts }}</h3>
         <ul>
@@ -8,6 +9,7 @@
             {{ end }}
         </ul>
     </div>
+    {{ end }}
 
     {{ with .Site.Taxonomies.tags }}
     <div id="tags" class="open">


### PR DESCRIPTION
This introduces a new setting called `codeeditor_menu_mostrecentposts` to disable the "Most recent posts" within the menu. While having a list of most recent posts is great for a blog or similar, it's not useful for all types of sites. The new setting defaults to `true`, so nothing changes for existing users.

Please let me know what you think about this! If you need anything changed ,please just drop me a note.